### PR TITLE
Fixes for recent OpenAI models and TW3

### DIFF
--- a/cmd/spot.go
+++ b/cmd/spot.go
@@ -364,7 +364,7 @@ func promptUserAction(client *taskwarrior.Client, spotlightTask SpotlightResult)
 		task, err := client.GetTaskByID(strconv.Itoa(spotlightTask.TaskID))
 		if err == nil {
 			task.Skipped ++
-			arg := "skipped:" + strconv.Itoa(task.Skipped)
+			arg := "skipped:" + strconv.Itoa(int(task.Skipped))
 			client.ModifyTaskInTaskWarrior(spotlightTask.TaskID, []string{arg})
 		} else {
 			return err

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -75,7 +75,7 @@ func (c *Client) Chat(messages []Message) (string, error) {
 	}
 
 	ctx := context.Background()
-	completion, err := c.llm.GenerateContent(ctx, llmMessages, llms.WithTemperature(0.7))
+	completion, err := c.llm.GenerateContent(ctx, llmMessages)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -12,7 +12,7 @@ type Task struct {
 	Entry       TWTime    `json:"entry"`
 	Modified    TWTime    `json:"modified"`
 	Urgency     float64   `json:"urgency,omitempty"`
-	Skipped		int		  `json:"skipped"`
+	Skipped		float64	  `json:"skipped"`
 }
 
 // type Goal struct {


### PR DESCRIPTION
Two very small fixes.  I do not consent to the CLA that is hidden away in this repository, for I do not want my code to appear in any proprietary software.

## fix: parse Skipped field as float64

TaskWarrior 3.0 serialized any numeric, even without decimal points, as a decimal.

## fix: remove fixed 0.7 temperature

This parameter is not supported in models newer than gpt-3.5.  Setting it will trigger an error 400.

The proposed upstream fix at https://github.com/tmc/langchaingo/pull/1199 will still set the temperature field if it's set, so even with that fix, we need to omit the temperature.