### PR TITLE
feat: add task annotations

### DIFF
--- a/cmd/spot.go
+++ b/cmd/spot.go
@@ -314,6 +314,14 @@ Here are the top pending tasks sorted by urgency:
 		if len(task.Tags) > 0 {
 			prompt += fmt.Sprintf(" [Tags: %s]", strings.Join(task.Tags, ", "))
 		}
+		if len(task.Annotations) > 0 {
+			prompt += " [Annotations: "
+			for _, annotation := range task.Annotations {
+				prompt += annotation.Entry + ": "+ annotation.Description
+				prompt += ", "
+			}
+			prompt += "]"
+		}
 		prompt += fmt.Sprintf(" (Urgency: %.2f)\n", task.Urgency)
 	}
 

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -13,6 +13,12 @@ type Task struct {
 	Modified    TWTime    `json:"modified"`
 	Urgency     float64   `json:"urgency,omitempty"`
 	Skipped		int		  `json:"skipped"`
+	Annotations []Annotation `json:"annotations,omitempty"`
+}
+
+type Annotation struct {
+	Entry       string    `json:"entry"`
+	Description string    `json:"description"`
 }
 
 // type Goal struct {


### PR DESCRIPTION
This allows the model to decide to not select a task if previously a reason has been given.

It would be great if a task got tagged with `+next` if a task gets selected, but I'm not versed well enough in Go to implement that currently.

N.b.: I do not consent to the CLA that is hidden away in this repository, for I do not want my code to appear in any proprietary software.